### PR TITLE
feat: simplify app extension

### DIFF
--- a/packages/flutter_robusta/CHANGELOG.md
+++ b/packages/flutter_robusta/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+- BC: replace `MaterialExtension` and `CupertinoExtension` with `AppExtension`.
+- Support settings `AppExtension` via `Configurator` extension.
+
 ## 0.1.0+1
 - Add README doc
 

--- a/packages/flutter_robusta/CHANGELOG.md
+++ b/packages/flutter_robusta/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.2.0
-- BC: replace `MaterialExtension` and `CupertinoExtension` with `AppExtension`.
+- BC: replace `MaterialExtension` and `CupertinoExtension` with `FlutterAppExtension`.
 - Support settings `AppExtension` via `Configurator` extension.
 
 ## 0.1.0+1

--- a/packages/flutter_robusta/README.md
+++ b/packages/flutter_robusta/README.md
@@ -40,7 +40,7 @@ class HomeScreen extends Screen implements InitialScreen {
 final runner = Runner(
   extensions: [
     ImplementingCallbackExtension(),
-    AppExtension(
+    FlutterAppExtension(
       routerSettings: RouterSettings(
         screenFactories: [
           (_) => HomeScreen(),

--- a/packages/flutter_robusta/README.md
+++ b/packages/flutter_robusta/README.md
@@ -40,7 +40,7 @@ class HomeScreen extends Screen implements InitialScreen {
 final runner = Runner(
   extensions: [
     ImplementingCallbackExtension(),
-    MaterialExtension(
+    AppExtension(
       routerSettings: RouterSettings(
         screenFactories: [
           (_) => HomeScreen(),
@@ -49,6 +49,7 @@ final runner = Runner(
     ),
   ],
 );
+
 
 Future<void> main() => runner.run();
 ```

--- a/packages/flutter_robusta/example/lib/main.dart
+++ b/packages/flutter_robusta/example/lib/main.dart
@@ -20,10 +20,10 @@ class HomeScreen extends Screen implements InitialScreen {
 final runner = Runner(
   extensions: [
     ImplementingCallbackExtension(),
-    MaterialExtension(
+    AppExtension(
       routerSettings: RouterSettings(
         screenFactories: [
-              (_) => HomeScreen(),
+          (_) => HomeScreen(),
         ],
       ),
     ),

--- a/packages/flutter_robusta/example/lib/main.dart
+++ b/packages/flutter_robusta/example/lib/main.dart
@@ -20,7 +20,7 @@ class HomeScreen extends Screen implements InitialScreen {
 final runner = Runner(
   extensions: [
     ImplementingCallbackExtension(),
-    AppExtension(
+    FlutterAppExtension(
       routerSettings: RouterSettings(
         screenFactories: [
           (_) => HomeScreen(),

--- a/packages/flutter_robusta/lib/flutter_robusta.dart
+++ b/packages/flutter_robusta/lib/flutter_robusta.dart
@@ -3,6 +3,7 @@ library flutter_robusta;
 
 export 'package:robusta_runner/robusta_runner.dart';
 
+export 'src/app_extension.dart';
 export 'src/cupertino.dart';
 export 'src/material.dart';
 export 'src/router.dart';

--- a/packages/flutter_robusta/lib/flutter_robusta.dart
+++ b/packages/flutter_robusta/lib/flutter_robusta.dart
@@ -3,7 +3,7 @@ library flutter_robusta;
 
 export 'package:robusta_runner/robusta_runner.dart';
 
-export 'src/app_extension.dart';
 export 'src/cupertino.dart';
+export 'src/extension.dart';
 export 'src/material.dart';
 export 'src/router.dart';

--- a/packages/flutter_robusta/lib/src/app_extension.dart
+++ b/packages/flutter_robusta/lib/src/app_extension.dart
@@ -7,6 +7,7 @@ import 'package:flutter_robusta/src/cupertino.dart';
 import 'package:flutter_robusta/src/material.dart';
 import 'package:flutter_robusta/src/router.dart';
 import 'package:go_router_plus/go_router_plus.dart';
+import 'package:meta/meta.dart';
 import 'package:robusta_runner/robusta_runner.dart';
 
 /// Use to wrap app widget with another widget for providing
@@ -16,6 +17,7 @@ typedef AppWidgetWrapper = Widget Function(Widget appWidget);
 /// {@template app_extension}
 /// Robusta extension for running Flutter apps.
 /// {@endtemplate}
+@sealed
 class AppExtension implements Extension {
   /// {@macro app_extension}
   AppExtension({

--- a/packages/flutter_robusta/lib/src/app_extension.dart
+++ b/packages/flutter_robusta/lib/src/app_extension.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_robusta/src/cupertino.dart';
+import 'package:flutter_robusta/src/material.dart';
 import 'package:flutter_robusta/src/router.dart';
 import 'package:go_router_plus/go_router_plus.dart';
-import 'package:meta/meta.dart';
 import 'package:robusta_runner/robusta_runner.dart';
 
 /// Use to wrap app widget with another widget for providing
@@ -12,21 +14,32 @@ import 'package:robusta_runner/robusta_runner.dart';
 typedef AppWidgetWrapper = Widget Function(Widget appWidget);
 
 /// {@template app_extension}
-/// App extension base of Material and Cupertino
+/// Robusta extension for running Flutter apps.
 /// {@endtemplate}
-@internal
-abstract class AppExtension implements Extension {
+class AppExtension implements Extension {
   /// {@macro app_extension}
   AppExtension({
+    required RouterSettings routerSettings,
     Map<AppWidgetWrapper, int>? wrappers,
-    RouterSettings? routerSettings,
-  })  : _wrappers = {...wrappers ?? {}},
-        routerSettings = routerSettings ?? RouterSettings();
+    CupertinoAppSettings? cupertinoAppSettings,
+    MaterialAppSettings? materialAppSettings,
+  })  : _routerSettings = routerSettings,
+        _wrappers = {...wrappers ?? {}},
+        _cupertinoAppSettings = cupertinoAppSettings,
+        _materialAppSettings = materialAppSettings {
+    /// Use Material as default app for running.
+    if (null == _materialAppSettings && null == _cupertinoAppSettings) {
+      _materialAppSettings = MaterialAppSettings();
+    }
+  }
 
   final Map<AppWidgetWrapper, int> _wrappers;
 
-  /// Settings of [GoRouter].
-  RouterSettings routerSettings;
+  RouterSettings _routerSettings;
+
+  MaterialAppSettings? _materialAppSettings;
+
+  CupertinoAppSettings? _cupertinoAppSettings;
 
   @override
   void load(Configurator configurator) {
@@ -48,7 +61,7 @@ abstract class AppExtension implements Extension {
 
   Future<void> _onRun(RunEvent event) async {
     final router = await _getRouter(event.container);
-    var app = appWidget(router);
+    var app = _appWidget(router);
 
     for (final wrapper in _sortedWrappers) {
       app = wrapper(app);
@@ -64,13 +77,70 @@ abstract class AppExtension implements Extension {
     runApp(app);
   }
 
-  /// App widget using to run.
-  @protected
-  Widget appWidget(GoRouter router);
+  Widget _appWidget(GoRouter router) {
+    if (null != _materialAppSettings) {
+      final settings = _materialAppSettings!;
 
-  /// Methods support nother extensions can collaborate.
-  void addAppWidgetWrapper(AppWidgetWrapper wrapper, {int priority = 0}) {
-    _wrappers[wrapper] = priority;
+      return MaterialApp.router(
+        routerConfig: router,
+        key: settings.key,
+        scaffoldMessengerKey: settings.scaffoldMessengerKey,
+        backButtonDispatcher: settings.backButtonDispatcher,
+        title: settings.title,
+        onGenerateTitle: settings.onGenerateTitle,
+        color: settings.color,
+        theme: settings.theme,
+        darkTheme: settings.darkTheme,
+        highContrastTheme: settings.highContrastTheme,
+        highContrastDarkTheme: settings.highContrastDarkTheme,
+        themeMode: settings.themeMode,
+        themeAnimationDuration: settings.themeAnimationDuration,
+        themeAnimationCurve: settings.themeAnimationCurve,
+        locale: settings.locale,
+        localizationsDelegates: settings.localizationsDelegates,
+        localeListResolutionCallback: settings.localeListResolutionCallback,
+        localeResolutionCallback: settings.localeResolutionCallback,
+        supportedLocales: settings.supportedLocales,
+        debugShowMaterialGrid: settings.debugShowMaterialGrid,
+        showPerformanceOverlay: settings.showPerformanceOverlay,
+        checkerboardRasterCacheImages: settings.checkerboardRasterCacheImages,
+        checkerboardOffscreenLayers: settings.checkerboardOffscreenLayers,
+        showSemanticsDebugger: settings.showSemanticsDebugger,
+        debugShowCheckedModeBanner: settings.debugShowCheckedModeBanner,
+        shortcuts: settings.shortcuts,
+        actions: settings.actions,
+        restorationScopeId: settings.restorationScopeId,
+        scrollBehavior: settings.scrollBehavior,
+        useInheritedMediaQuery: settings.useInheritedMediaQuery,
+      );
+    }
+
+    final settings = _cupertinoAppSettings!;
+
+    return CupertinoApp.router(
+      routerConfig: router,
+      key: settings.key,
+      backButtonDispatcher: settings.backButtonDispatcher,
+      title: settings.title,
+      onGenerateTitle: settings.onGenerateTitle,
+      color: settings.color,
+      theme: settings.theme,
+      locale: settings.locale,
+      localizationsDelegates: settings.localizationsDelegates,
+      localeListResolutionCallback: settings.localeListResolutionCallback,
+      localeResolutionCallback: settings.localeResolutionCallback,
+      supportedLocales: settings.supportedLocales,
+      showPerformanceOverlay: settings.showPerformanceOverlay,
+      checkerboardRasterCacheImages: settings.checkerboardRasterCacheImages,
+      checkerboardOffscreenLayers: settings.checkerboardOffscreenLayers,
+      showSemanticsDebugger: settings.showSemanticsDebugger,
+      debugShowCheckedModeBanner: settings.debugShowCheckedModeBanner,
+      shortcuts: settings.shortcuts,
+      actions: settings.actions,
+      restorationScopeId: settings.restorationScopeId,
+      scrollBehavior: settings.scrollBehavior,
+      useInheritedMediaQuery: settings.useInheritedMediaQuery,
+    );
   }
 
   Iterable<AppWidgetWrapper> get _sortedWrappers {
@@ -82,18 +152,56 @@ abstract class AppExtension implements Extension {
     return entries.map((e) => e.key);
   }
 
-  /// Get router based on current [routerSettings] values.
+  /// Get router based on current [_routerSettings] values.
   Future<GoRouter> _getRouter(ProviderContainer container) async {
     return createGoRouter(
-      screens: await routerSettings.getScreens(container),
-      observers: await routerSettings.getNavigatorObservers(container),
-      redirectors: await routerSettings.getRedirectors(container),
-      refreshNotifiers: await routerSettings.getRefreshNotifiers(container),
-      navigatorKey: routerSettings.navigatorKey,
-      debugLogDiagnostics: routerSettings.debugLogDiagnostics,
-      redirectLimit: routerSettings.redirectLimit,
-      restorationScopeId: routerSettings.restorationScopeId,
-      routerNeglect: routerSettings.routerNeglect,
+      screens: await _routerSettings.getScreens(container),
+      observers: await _routerSettings.getNavigatorObservers(container),
+      redirectors: await _routerSettings.getRedirectors(container),
+      refreshNotifiers: await _routerSettings.getRefreshNotifiers(container),
+      navigatorKey: _routerSettings.navigatorKey,
+      debugLogDiagnostics: _routerSettings.debugLogDiagnostics,
+      redirectLimit: _routerSettings.redirectLimit,
+      restorationScopeId: _routerSettings.restorationScopeId,
+      routerNeglect: _routerSettings.routerNeglect,
     );
+  }
+}
+
+/// Dart extension for adding utils to interact with [AppExtension].
+extension AppExtensionConfigurator on Configurator {
+  /// Get [GoRouter] settings.
+  RouterSettings get routerSettings {
+    return getExtension<AppExtension>()._routerSettings;
+  }
+
+  /// Set [GoRouter] settings.
+  set routerSettings(RouterSettings settings) {
+    getExtension<AppExtension>()._routerSettings = settings;
+  }
+
+  /// Get [MaterialApp] settings.
+  MaterialAppSettings? get materialAppSettings {
+    return getExtension<AppExtension>()._materialAppSettings;
+  }
+
+  /// Set [MaterialApp] settings.
+  set materialAppSettings(MaterialAppSettings? settings) {
+    getExtension<AppExtension>()._materialAppSettings = settings;
+  }
+
+  /// Get [CupertinoApp] settings.
+  CupertinoAppSettings? get cupertinoAppSettings {
+    return getExtension<AppExtension>()._cupertinoAppSettings;
+  }
+
+  /// Set [CupertinoApp] settings.
+  set cupertinoAppSettings(CupertinoAppSettings? settings) {
+    getExtension<AppExtension>()._cupertinoAppSettings = settings;
+  }
+
+  /// Add app wrapper for adding feature like inherited widget for your app.
+  void addAppWidgetWrapper(AppWidgetWrapper wrapper, {int priority = 0}) {
+    getExtension<AppExtension>()._wrappers[wrapper] = priority;
   }
 }

--- a/packages/flutter_robusta/lib/src/cupertino.dart
+++ b/packages/flutter_robusta/lib/src/cupertino.dart
@@ -1,5 +1,6 @@
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 
 part 'cupertino.g.dart';
 
@@ -7,6 +8,7 @@ part 'cupertino.g.dart';
 /// Instances of this class will support setting [CupertinoApp]'s properties.
 /// {@endtemplate cupertino.settings}
 @CopyWith(skipFields: true)
+@sealed
 class CupertinoAppSettings {
   /// {macro cupertino.settings}
   CupertinoAppSettings({

--- a/packages/flutter_robusta/lib/src/cupertino.dart
+++ b/packages/flutter_robusta/lib/src/cupertino.dart
@@ -1,8 +1,5 @@
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_robusta/src/app_extension.dart';
-import 'package:go_router_plus/go_router_plus.dart';
-import 'package:meta/meta.dart';
 
 part 'cupertino.g.dart';
 
@@ -98,49 +95,4 @@ class CupertinoAppSettings {
 
   /// Alias of [CupertinoApp.useInheritedMediaQuery]
   final bool useInheritedMediaQuery;
-}
-
-/// {@template cupertino_extension}
-/// An extension to settings, run [CupertinoApp] with [GoRouter], and open for
-/// collaboration of other extensions.
-/// {@endtemplate}
-@sealed
-class CupertinoExtension extends AppExtension {
-  /// {@macro cupertino_extension}
-  CupertinoExtension({
-    super.wrappers,
-    super.routerSettings,
-    CupertinoAppSettings? settings,
-  }) : settings = settings ?? CupertinoAppSettings();
-
-  /// Store settings of [CupertinoApp].
-  CupertinoAppSettings settings;
-
-  @override
-  CupertinoApp appWidget(GoRouter router) {
-    return CupertinoApp.router(
-      routerConfig: router,
-      key: settings.key,
-      backButtonDispatcher: settings.backButtonDispatcher,
-      title: settings.title,
-      onGenerateTitle: settings.onGenerateTitle,
-      color: settings.color,
-      theme: settings.theme,
-      locale: settings.locale,
-      localizationsDelegates: settings.localizationsDelegates,
-      localeListResolutionCallback: settings.localeListResolutionCallback,
-      localeResolutionCallback: settings.localeResolutionCallback,
-      supportedLocales: settings.supportedLocales,
-      showPerformanceOverlay: settings.showPerformanceOverlay,
-      checkerboardRasterCacheImages: settings.checkerboardRasterCacheImages,
-      checkerboardOffscreenLayers: settings.checkerboardOffscreenLayers,
-      showSemanticsDebugger: settings.showSemanticsDebugger,
-      debugShowCheckedModeBanner: settings.debugShowCheckedModeBanner,
-      shortcuts: settings.shortcuts,
-      actions: settings.actions,
-      restorationScopeId: settings.restorationScopeId,
-      scrollBehavior: settings.scrollBehavior,
-      useInheritedMediaQuery: settings.useInheritedMediaQuery,
-    );
-  }
 }

--- a/packages/flutter_robusta/lib/src/extension.dart
+++ b/packages/flutter_robusta/lib/src/extension.dart
@@ -18,9 +18,9 @@ typedef AppWidgetWrapper = Widget Function(Widget appWidget);
 /// Robusta extension for running Flutter apps.
 /// {@endtemplate}
 @sealed
-class AppExtension implements Extension {
+class FlutterAppExtension implements Extension {
   /// {@macro app_extension}
-  AppExtension({
+  FlutterAppExtension({
     required RouterSettings routerSettings,
     Map<AppWidgetWrapper, int>? wrappers,
     CupertinoAppSettings? cupertinoAppSettings,
@@ -170,40 +170,40 @@ class AppExtension implements Extension {
   }
 }
 
-/// Dart extension for adding utils to interact with [AppExtension].
-extension AppExtensionConfigurator on Configurator {
+/// Dart extension for adding utils to interact with [FlutterAppExtension].
+extension FlutterAppExtensionConfigurator on Configurator {
   /// Get [GoRouter] settings.
   RouterSettings get routerSettings {
-    return getExtension<AppExtension>()._routerSettings;
+    return getExtension<FlutterAppExtension>()._routerSettings;
   }
 
   /// Set [GoRouter] settings.
   set routerSettings(RouterSettings settings) {
-    getExtension<AppExtension>()._routerSettings = settings;
+    getExtension<FlutterAppExtension>()._routerSettings = settings;
   }
 
   /// Get [MaterialApp] settings.
   MaterialAppSettings? get materialAppSettings {
-    return getExtension<AppExtension>()._materialAppSettings;
+    return getExtension<FlutterAppExtension>()._materialAppSettings;
   }
 
   /// Set [MaterialApp] settings.
   set materialAppSettings(MaterialAppSettings? settings) {
-    getExtension<AppExtension>()._materialAppSettings = settings;
+    getExtension<FlutterAppExtension>()._materialAppSettings = settings;
   }
 
   /// Get [CupertinoApp] settings.
   CupertinoAppSettings? get cupertinoAppSettings {
-    return getExtension<AppExtension>()._cupertinoAppSettings;
+    return getExtension<FlutterAppExtension>()._cupertinoAppSettings;
   }
 
   /// Set [CupertinoApp] settings.
   set cupertinoAppSettings(CupertinoAppSettings? settings) {
-    getExtension<AppExtension>()._cupertinoAppSettings = settings;
+    getExtension<FlutterAppExtension>()._cupertinoAppSettings = settings;
   }
 
   /// Add app wrapper for adding feature like inherited widget for your app.
   void addAppWidgetWrapper(AppWidgetWrapper wrapper, {int priority = 0}) {
-    getExtension<AppExtension>()._wrappers[wrapper] = priority;
+    getExtension<FlutterAppExtension>()._wrappers[wrapper] = priority;
   }
 }

--- a/packages/flutter_robusta/lib/src/material.dart
+++ b/packages/flutter_robusta/lib/src/material.dart
@@ -1,8 +1,5 @@
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_robusta/src/app_extension.dart';
-import 'package:go_router_plus/go_router_plus.dart';
-import 'package:meta/meta.dart';
 
 part 'material.g.dart';
 
@@ -130,57 +127,4 @@ class MaterialAppSettings {
 
   /// Alias of [MaterialApp.useInheritedMediaQuery]
   final bool useInheritedMediaQuery;
-}
-
-/// {@template material_extension}
-/// An extension to settings, run [MaterialApp] with [GoRouter], and open for
-/// collaboration of other extensions.
-/// {@endtemplate}
-@sealed
-class MaterialExtension extends AppExtension {
-  /// {@macro material_extension}
-  MaterialExtension({
-    super.wrappers,
-    super.routerSettings,
-    MaterialAppSettings? settings,
-  }) : settings = settings ?? MaterialAppSettings();
-
-  /// Store settings of [MaterialApp].
-  MaterialAppSettings settings;
-
-  @override
-  MaterialApp appWidget(GoRouter router) {
-    return MaterialApp.router(
-      routerConfig: router,
-      key: settings.key,
-      scaffoldMessengerKey: settings.scaffoldMessengerKey,
-      backButtonDispatcher: settings.backButtonDispatcher,
-      title: settings.title,
-      onGenerateTitle: settings.onGenerateTitle,
-      color: settings.color,
-      theme: settings.theme,
-      darkTheme: settings.darkTheme,
-      highContrastTheme: settings.highContrastTheme,
-      highContrastDarkTheme: settings.highContrastDarkTheme,
-      themeMode: settings.themeMode,
-      themeAnimationDuration: settings.themeAnimationDuration,
-      themeAnimationCurve: settings.themeAnimationCurve,
-      locale: settings.locale,
-      localizationsDelegates: settings.localizationsDelegates,
-      localeListResolutionCallback: settings.localeListResolutionCallback,
-      localeResolutionCallback: settings.localeResolutionCallback,
-      supportedLocales: settings.supportedLocales,
-      debugShowMaterialGrid: settings.debugShowMaterialGrid,
-      showPerformanceOverlay: settings.showPerformanceOverlay,
-      checkerboardRasterCacheImages: settings.checkerboardRasterCacheImages,
-      checkerboardOffscreenLayers: settings.checkerboardOffscreenLayers,
-      showSemanticsDebugger: settings.showSemanticsDebugger,
-      debugShowCheckedModeBanner: settings.debugShowCheckedModeBanner,
-      shortcuts: settings.shortcuts,
-      actions: settings.actions,
-      restorationScopeId: settings.restorationScopeId,
-      scrollBehavior: settings.scrollBehavior,
-      useInheritedMediaQuery: settings.useInheritedMediaQuery,
-    );
-  }
 }

--- a/packages/flutter_robusta/lib/src/material.dart
+++ b/packages/flutter_robusta/lib/src/material.dart
@@ -1,5 +1,6 @@
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
 part 'material.g.dart';
 
@@ -7,6 +8,7 @@ part 'material.g.dart';
 /// Instances of this class will support settings [MaterialApp]'s properties.
 /// {@endtemplate material.settings}
 @CopyWith(skipFields: true)
+@sealed
 class MaterialAppSettings {
   /// {@macro material.settings}
   MaterialAppSettings({

--- a/packages/flutter_robusta/lib/src/router.dart
+++ b/packages/flutter_robusta/lib/src/router.dart
@@ -4,6 +4,7 @@ import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router_plus/go_router_plus.dart';
+import 'package:meta/meta.dart';
 
 part 'router.g.dart';
 
@@ -28,6 +29,7 @@ typedef NavigatorObserverFactory = _Factory<NavigatorObserver>;
 /// Instances of this class supports router settings.
 /// {@endtemplate}
 @CopyWith(skipFields: true)
+@sealed
 class RouterSettings {
   /// {@macro router.settings}
   RouterSettings({

--- a/packages/flutter_robusta/pubspec.yaml
+++ b/packages/flutter_robusta/pubspec.yaml
@@ -3,7 +3,7 @@ homepage: https://robusta.covalab.io
 repository: https://github.com/covalab/robusta
 issue_tracker: https://github.com/covalab/robusta/issues
 description: Robusta runner extensions for Flutter.
-version: 0.1.0+1
+version: 0.2.0
 
 environment:
   sdk: ">=2.19.0 <3.0.0"

--- a/packages/flutter_robusta/test/src/app_extension_test.dart
+++ b/packages/flutter_robusta/test/src/app_extension_test.dart
@@ -8,14 +8,14 @@ import 'stub.dart';
 void main() {
   group('material extension', () {
     test('can initialize', () {
-      expect(AppExtension(routerSettings: RouterSettings()), isNotNull);
+      expect(FlutterAppExtension(routerSettings: RouterSettings()), isNotNull);
     });
 
     testWidgets('can boot and run default Material app', (tester) async {
       final runner = Runner(
         extensions: [
           TestExtension(),
-          AppExtension(routerSettings: RouterSettings()),
+          FlutterAppExtension(routerSettings: RouterSettings()),
         ],
       );
 
@@ -30,7 +30,7 @@ void main() {
       final runner = Runner(
         extensions: [
           TestExtension(),
-          AppExtension(
+          FlutterAppExtension(
             cupertinoAppSettings: CupertinoAppSettings(),
             routerSettings: RouterSettings(),
           ),
@@ -48,7 +48,7 @@ void main() {
       final runner = Runner(
         extensions: [
           TestExtension(),
-          AppExtension(
+          FlutterAppExtension(
             routerSettings: RouterSettings(),
             wrappers: {
               (widget) =>
@@ -69,7 +69,7 @@ void main() {
       final runner = Runner(
         extensions: [
           TestExtension(),
-          AppExtension(
+          FlutterAppExtension(
             routerSettings: RouterSettings(),
             wrappers: {
               (widget) {

--- a/packages/flutter_robusta/test/src/app_extension_test.dart
+++ b/packages/flutter_robusta/test/src/app_extension_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_robusta/flutter_robusta.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'stub.dart';
+
+void main() {
+  group('material extension', () {
+    test('can initialize', () {
+      expect(AppExtension(routerSettings: RouterSettings()), isNotNull);
+    });
+
+    testWidgets('can boot and run default Material app', (tester) async {
+      final runner = Runner(
+        extensions: [
+          TestExtension(),
+          AppExtension(routerSettings: RouterSettings()),
+        ],
+      );
+
+      await runner.run();
+
+      await tester.pump();
+
+      expect(find.text('Material App'), findsOneWidget);
+    });
+
+    testWidgets('can boot and run Cupertino App', (tester) async {
+      final runner = Runner(
+        extensions: [
+          TestExtension(),
+          AppExtension(
+            cupertinoAppSettings: CupertinoAppSettings(),
+            routerSettings: RouterSettings(),
+          ),
+        ],
+      );
+
+      await runner.run();
+
+      await tester.pump();
+
+      expect(find.text('Cupertino App'), findsOneWidget);
+    });
+
+    testWidgets('can add app wrapper', (tester) async {
+      final runner = Runner(
+        extensions: [
+          TestExtension(),
+          AppExtension(
+            routerSettings: RouterSettings(),
+            wrappers: {
+              (widget) =>
+                  const Text('Wrapped', textDirection: TextDirection.ltr): 0,
+            },
+          ),
+        ],
+      );
+
+      await runner.run();
+
+      await tester.pump();
+
+      expect(find.text('Wrapped'), findsOneWidget);
+    });
+
+    testWidgets('can use Riverpod features', (tester) async {
+      final runner = Runner(
+        extensions: [
+          TestExtension(),
+          AppExtension(
+            routerSettings: RouterSettings(),
+            wrappers: {
+              (widget) {
+                return Consumer(
+                  builder: (ctx, ref, child) {
+                    return Text(
+                      ref.read(testState),
+                      textDirection: TextDirection.ltr,
+                    );
+                  },
+                );
+              }: 0,
+            },
+          ),
+        ],
+      );
+
+      await runner.run();
+
+      await tester.pump();
+
+      expect(find.text('Test State'), findsOneWidget);
+    });
+  });
+}

--- a/packages/flutter_robusta/test/src/cupertino_test.dart
+++ b/packages/flutter_robusta/test/src/cupertino_test.dart
@@ -1,11 +1,8 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_robusta/flutter_robusta.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'stub.dart';
 
 void main() {
   group('cupertino settings', () {
@@ -24,72 +21,6 @@ void main() {
 
       expect(cloneInstance.supportedLocales, [Locale('VI'), Locale('US')]);
       expect(cloneInstance.color, Color.fromRGBO(0, 0, 0, 0));
-    });
-  });
-
-  group('cupertino extension', () {
-    test('can initialize', () {
-      expect(CupertinoExtension(), isNotNull);
-    });
-
-    testWidgets('can boot and run apps', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          CupertinoExtension(),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Test Screen'), findsOneWidget);
-    });
-
-    testWidgets('can add app wrapper', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          CupertinoExtension(
-            wrappers: {
-              (widget) => Text('Wrapped', textDirection: TextDirection.ltr): 0,
-            },
-          ),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Wrapped'), findsOneWidget);
-    });
-
-    testWidgets('can use Riverpod features', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          CupertinoExtension(
-            wrappers: {
-              (widget) {
-                return Consumer(
-                  builder: (_, ref, child) => Text(
-                    ref.read(testState),
-                    textDirection: TextDirection.ltr,
-                  ),
-                );
-              }: 0,
-            },
-          ),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Test State'), findsOneWidget);
     });
   });
 }

--- a/packages/flutter_robusta/test/src/material_test.dart
+++ b/packages/flutter_robusta/test/src/material_test.dart
@@ -1,11 +1,8 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_robusta/flutter_robusta.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'stub.dart';
 
 void main() {
   group('material settings', () {
@@ -24,72 +21,6 @@ void main() {
 
       expect(cloneInstance.supportedLocales, [Locale('VI'), Locale('US')]);
       expect(cloneInstance.color, Color.fromRGBO(0, 0, 0, 0));
-    });
-  });
-
-  group('material extension', () {
-    test('can initialize', () {
-      expect(MaterialExtension(), isNotNull);
-    });
-
-    testWidgets('can boot and run apps', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          MaterialExtension(),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Test Screen'), findsOneWidget);
-    });
-
-    testWidgets('can add app wrapper', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          MaterialExtension(
-            wrappers: {
-              (widget) => Text('Wrapped', textDirection: TextDirection.ltr): 0,
-            },
-          ),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Wrapped'), findsOneWidget);
-    });
-
-    testWidgets('can use Riverpod features', (tester) async {
-      final runner = Runner(
-        extensions: [
-          TestExtension(),
-          MaterialExtension(
-            wrappers: {
-              (widget) {
-                return Consumer(
-                  builder: (_, ref, child) => Text(
-                    ref.read(testState),
-                    textDirection: TextDirection.ltr,
-                  ),
-                );
-              }: 0,
-            },
-          ),
-        ],
-      );
-
-      await runner.run();
-
-      await tester.pump();
-
-      expect(find.text('Test State'), findsOneWidget);
     });
   });
 }

--- a/packages/flutter_robusta/test/src/stub.dart
+++ b/packages/flutter_robusta/test/src/stub.dart
@@ -1,30 +1,27 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_robusta/flutter_robusta.dart';
 import 'package:go_router_plus/go_router_plus.dart';
 
 final testState = StateProvider<String>((_) => 'Test State');
 
-class TestExtension implements Extension {
+class TestExtension implements DependenceExtension {
   @override
   void load(Configurator configurator) {
-    if (configurator.hasExtension<MaterialExtension>()) {
-      final extension = configurator.getExtension<MaterialExtension>();
-      extension.routerSettings.screenFactories.add((_) => TestScreen());
-    }
-
-    if (configurator.hasExtension<CupertinoExtension>()) {
-      final extension = configurator.getExtension<CupertinoExtension>();
-      extension.routerSettings.screenFactories.add((_) => TestScreen());
-    }
+    configurator.routerSettings.screenFactories.add((_) => TestScreen());
   }
+
+  @override
+  List<Type> dependsOn() => [AppExtension];
 }
 
 class TestScreen extends Screen implements InitialScreen {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const Text(
-      'Test Screen',
+    final isCupertino = isCupertinoApp(context as Element);
+
+    return Text(
+      !isCupertino ? 'Material App' : 'Cupertino App',
       textDirection: TextDirection.ltr,
     );
   }
@@ -34,4 +31,8 @@ class TestScreen extends Screen implements InitialScreen {
 
   @override
   String get routePath => '/test';
+
+  /// Checks for MaterialApp in the widget tree.
+  bool isCupertinoApp(Element elem) =>
+      elem.findAncestorWidgetOfExactType<CupertinoApp>() != null;
 }

--- a/packages/flutter_robusta/test/src/stub.dart
+++ b/packages/flutter_robusta/test/src/stub.dart
@@ -32,7 +32,7 @@ class TestScreen extends Screen implements InitialScreen {
   @override
   String get routePath => '/test';
 
-  /// Checks for MaterialApp in the widget tree.
+  /// Checks for CupertinoApp in the widget tree.
   bool isCupertinoApp(Element elem) =>
       elem.findAncestorWidgetOfExactType<CupertinoApp>() != null;
 }

--- a/packages/flutter_robusta/test/src/stub.dart
+++ b/packages/flutter_robusta/test/src/stub.dart
@@ -12,7 +12,7 @@ class TestExtension implements DependenceExtension {
   }
 
   @override
-  List<Type> dependsOn() => [AppExtension];
+  List<Type> dependsOn() => [FlutterAppExtension];
 }
 
 class TestScreen extends Screen implements InitialScreen {


### PR DESCRIPTION
## Status

**READY**

## Description

- Replace `MaterialExtension` and `CupertinoExtension` with `FlutterAppExtension`.

- Another extension now can use the `Configurator` arg to collaborate app settings to reduce complexity.

Before simplify:

```dart
class TestExtension implements Extension {
  @override
  void load(Configurator configurator) {
    if (configurator.hasExtension<MaterialExtension>()) {
      final extension = configurator.getExtension<MaterialExtension>();
      extension.routerSettings.screenFactories.add((_) => TestScreen());
    }

    if (configurator.hasExtension<CupertinoExtension>()) {
      final extension = configurator.getExtension<CupertinoExtension>();
      extension.routerSettings.screenFactories.add((_) => TestScreen());
    }
  }
}
```

After simplify:

```dart
class TestExtension implements DependenceExtension {
  @override
  void load(Configurator configurator) {
    configurator.routerSettings.screenFactories.add((_) => TestScreen());
  }

  @override
  List<Type> dependsOn() => [FlutterAppExtension];
}
```

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
