### PR TITLE
fix(flutter_robusta)!: remove deprecated app settings

### DIFF
--- a/packages/flutter_robusta/lib/src/cupertino.dart
+++ b/packages/flutter_robusta/lib/src/cupertino.dart
@@ -32,7 +32,6 @@ class CupertinoAppSettings {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
-    this.useInheritedMediaQuery = false,
   });
 
   /// Alias of [CupertinoApp.key]
@@ -94,7 +93,4 @@ class CupertinoAppSettings {
 
   /// Alias of [CupertinoApp.scrollBehavior]
   final ScrollBehavior? scrollBehavior;
-
-  /// Alias of [CupertinoApp.useInheritedMediaQuery]
-  final bool useInheritedMediaQuery;
 }

--- a/packages/flutter_robusta/lib/src/cupertino.g.dart
+++ b/packages/flutter_robusta/lib/src/cupertino.g.dart
@@ -35,7 +35,6 @@ abstract class _$CupertinoAppSettingsCWProxy {
     Map<Type, Action<Intent>>? actions,
     String? restorationScopeId,
     ScrollBehavior? scrollBehavior,
-    bool? useInheritedMediaQuery,
   });
 }
 
@@ -75,7 +74,6 @@ class _$CupertinoAppSettingsCWProxyImpl
     Object? actions = const $CopyWithPlaceholder(),
     Object? restorationScopeId = const $CopyWithPlaceholder(),
     Object? scrollBehavior = const $CopyWithPlaceholder(),
-    Object? useInheritedMediaQuery = const $CopyWithPlaceholder(),
   }) {
     return CupertinoAppSettings(
       key: key == const $CopyWithPlaceholder()
@@ -174,12 +172,6 @@ class _$CupertinoAppSettingsCWProxyImpl
           ? _value.scrollBehavior
           // ignore: cast_nullable_to_non_nullable
           : scrollBehavior as ScrollBehavior?,
-      useInheritedMediaQuery:
-          useInheritedMediaQuery == const $CopyWithPlaceholder() ||
-                  useInheritedMediaQuery == null
-              ? _value.useInheritedMediaQuery
-              // ignore: cast_nullable_to_non_nullable
-              : useInheritedMediaQuery as bool,
     );
   }
 }

--- a/packages/flutter_robusta/lib/src/extension.dart
+++ b/packages/flutter_robusta/lib/src/extension.dart
@@ -127,7 +127,6 @@ class FlutterAppExtension implements Extension {
         actions: settings.actions,
         restorationScopeId: settings.restorationScopeId,
         scrollBehavior: settings.scrollBehavior,
-        useInheritedMediaQuery: settings.useInheritedMediaQuery,
       );
     }
 
@@ -155,7 +154,6 @@ class FlutterAppExtension implements Extension {
       actions: settings.actions,
       restorationScopeId: settings.restorationScopeId,
       scrollBehavior: settings.scrollBehavior,
-      useInheritedMediaQuery: settings.useInheritedMediaQuery,
     );
   }
 

--- a/packages/flutter_robusta/lib/src/material.dart
+++ b/packages/flutter_robusta/lib/src/material.dart
@@ -40,7 +40,6 @@ class MaterialAppSettings {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
-    this.useInheritedMediaQuery = false,
   });
 
   /// Alias of [MaterialApp.key]
@@ -126,7 +125,4 @@ class MaterialAppSettings {
 
   /// Alias of [MaterialApp.debugShowMaterialGrid]
   final bool debugShowMaterialGrid;
-
-  /// Alias of [MaterialApp.useInheritedMediaQuery]
-  final bool useInheritedMediaQuery;
 }

--- a/packages/flutter_robusta/lib/src/material.g.dart
+++ b/packages/flutter_robusta/lib/src/material.g.dart
@@ -43,7 +43,6 @@ abstract class _$MaterialAppSettingsCWProxy {
     Map<Type, Action<Intent>>? actions,
     String? restorationScopeId,
     ScrollBehavior? scrollBehavior,
-    bool? useInheritedMediaQuery,
   });
 }
 
@@ -90,7 +89,6 @@ class _$MaterialAppSettingsCWProxyImpl implements _$MaterialAppSettingsCWProxy {
     Object? actions = const $CopyWithPlaceholder(),
     Object? restorationScopeId = const $CopyWithPlaceholder(),
     Object? scrollBehavior = const $CopyWithPlaceholder(),
-    Object? useInheritedMediaQuery = const $CopyWithPlaceholder(),
   }) {
     return MaterialAppSettings(
       key: key == const $CopyWithPlaceholder()
@@ -228,12 +226,6 @@ class _$MaterialAppSettingsCWProxyImpl implements _$MaterialAppSettingsCWProxy {
           ? _value.scrollBehavior
           // ignore: cast_nullable_to_non_nullable
           : scrollBehavior as ScrollBehavior?,
-      useInheritedMediaQuery:
-          useInheritedMediaQuery == const $CopyWithPlaceholder() ||
-                  useInheritedMediaQuery == null
-              ? _value.useInheritedMediaQuery
-              // ignore: cast_nullable_to_non_nullable
-              : useInheritedMediaQuery as bool,
     );
   }
 }


### PR DESCRIPTION
## Status

**READY**

## Description

+ Since Flutter 3.7 app settings `useInheritedMediaQuery` are deprecated we should avoid it.

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
